### PR TITLE
Test another kernel version

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # The kernel versions we want to run the tests on
-readonly kernel_versions=("4.9.96")
+readonly kernel_versions=("4.14.37", "4.16.0", "4.4.129", "4.9.96")
 
 # The rkt version which is set as a dependency for
 # the custom stage1-kvm images

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -26,6 +26,10 @@ fi
 # https://github.com/coreos/rkt/issues/2241
 sudo ./rkt/rkt image fetch --insecure-options=image "coreos.com/rkt/stage1-kvm:${rkt_version}" >/dev/null
 
+# https://github.com/rkt/rkt/issues/2928
+sudo iptables -A FORWARD -d 172.16.28.0/24 -j ACCEPT
+sudo iptables -A FORWARD -s 172.16.28.0/24 -j ACCEPT
+
 for kernel_version in "${kernel_versions[@]}"; do
   kernel_header_dir="/lib/modules/${kernel_version}-kinvolk-v1/source/include"
   # The stage1-kvm image to use for the tests
@@ -33,10 +37,6 @@ for kernel_version in "${kernel_versions[@]}"; do
 
   # Make sure there's no stale rkt-uuid file
   rm -f ./rkt-uuid
-
-  # https://github.com/rkt/rkt/issues/2928
-  sudo iptables -A FORWARD -d 172.16.28.0/24 -j ACCEPT
-  sudo iptables -A FORWARD -s 172.16.28.0/24 -j ACCEPT
 
   # You most likely want to provide source code to the
   # container in order to run the tests. You can do this

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # The kernel versions we want to run the tests on
-readonly kernel_versions=("4.14.37" "4.4.129" "4.9.96")
+readonly kernel_versions=("4.14.37" "4.9.96")
 
 # The rkt version which is set as a dependency for
 # the custom stage1-kvm images

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # The kernel versions we want to run the tests on
-readonly kernel_versions=("4.14.37" "4.16.0" "4.4.129" "4.9.96")
+readonly kernel_versions=("4.14.37" "4.4.129" "4.9.96")
 
 # The rkt version which is set as a dependency for
 # the custom stage1-kvm images

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # The kernel versions we want to run the tests on
-readonly kernel_versions=("4.14.37", "4.16.0", "4.4.129", "4.9.96")
+readonly kernel_versions=("4.14.37" "4.16.0" "4.4.129" "4.9.96")
 
 # The rkt version which is set as a dependency for
 # the custom stage1-kvm images


### PR DESCRIPTION
Test with Linux Kernel "4.14.37" and "4.9.96" .
`bpf_get_current_task()` is included from version 4.8, so it targets 4.8 or higher kernels.